### PR TITLE
Implement Error for RLNCError

### DIFF
--- a/src/common/errors.rs
+++ b/src/common/errors.rs
@@ -52,3 +52,5 @@ impl std::fmt::Display for RLNCError {
         }
     }
 }
+
+impl std::error::Error for RLNCError {}


### PR DESCRIPTION
Adds std::error::Error impl to make it easier to use with libraries like anyhow.

