### PR TITLE
gf256: precompute full multiplication tables

### DIFF
--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -2,5 +2,7 @@ pub mod errors;
 pub mod gf256;
 pub mod simd;
 
+mod mul_table;
+
 #[cfg(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64"))]
 mod simd_mul_table;

--- a/src/common/mul_table.rs
+++ b/src/common/mul_table.rs
@@ -1,0 +1,20 @@
+use super::gf256::{GF256_ORDER, Gf256};
+
+const fn gen_mul_table() -> [[u8; GF256_ORDER]; GF256_ORDER] {
+    let mut table = [[0u8; GF256_ORDER]; GF256_ORDER];
+
+    let mut row_idx = 0;
+    while row_idx < GF256_ORDER {
+        let mut col_idx = 0;
+
+        while col_idx < GF256_ORDER {
+            table[row_idx][col_idx] = Gf256::mul_const(row_idx as u8, col_idx as u8);
+            col_idx += 1;
+        }
+        row_idx += 1;
+    }
+
+    table
+}
+
+pub const GF256_TABLES: [[u8; GF256_ORDER]; GF256_ORDER] = gen_mul_table();

--- a/src/common/simd/mod.rs
+++ b/src/common/simd/mod.rs
@@ -1,4 +1,7 @@
-use crate::common::gf256::Gf256;
+use crate::common::{
+    gf256::Gf256,
+    mul_table::GF256_TABLES,
+};
 
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 mod x86;
@@ -86,6 +89,7 @@ pub fn gf256_inplace_add_vectors(vec_dst: &mut [u8], vec_src: &[u8]) {
 ///
 /// This function can be thought of an optimization over, first applying `gf256_inplace_mul_vec_by_scalar`
 /// and then applying `gf256_inplace_add_vectors`.
+
 pub fn gf256_mul_vec_by_scalar_then_add_into_vec(add_into_vec: &mut [u8], mul_vec: &[u8], scalar: u8) {
     if add_into_vec.is_empty() {
         return;
@@ -112,8 +116,15 @@ pub fn gf256_mul_vec_by_scalar_then_add_into_vec(add_into_vec: &mut [u8], mul_ve
         }
     }
 
-    add_into_vec
-        .iter_mut()
-        .zip(mul_vec.iter().map(|&src_symbol| Gf256::mul_const(src_symbol, scalar)))
-        .for_each(|(res, scaled)| *res ^= scaled);
+    let table = &GF256_TABLES[scalar as usize];
+    let len = add_into_vec.len().min(mul_vec.len());
+
+    // Re-slicing to the same length helps the compiler remove bounds checks
+    let d = &mut add_into_vec[..len];
+    let s = &mul_vec[..len];
+
+    for i in 0..len {
+        d[i] ^= table[s[i] as usize];
+    }
+
 }


### PR DESCRIPTION
use table lookup in scalar fallback

Replace per-call GF(256) multiplication with a compile-time generated 256×256 lookup table
 and use it in the scalar gf256_mul_vec_by_scalar_then_add_into_vec fallback path.

This removes runtime table construction and per-element GF arithmetic, reducing the hot loop to indexed loads and XORs.
 SIMD dispatch remains unchanged; SIMD backends continue to use their specialized implementations.

Performance impact:
Significant improvements on non-SIMD targets (e.g. WASM, legacy CPUs):
AMD Phenom II x6:
encode/1.0MB/16-pieces  time:   [1.1116 ms 1.1245 ms 1.1343 ms]
                        thrpt:  [936.70 MiB/s 944.93 MiB/s 955.83 MiB/s]
                 change:
                        time:   [−57.581% −56.812% −56.132%] (p = 0.00 < 0.05)
                        thrpt:  [+127.96% +131.55% +135.74%]
                        Performance has improved.

WASM (Intel(R) Core(TM) i5-7300U CPU @ 2.60GHz):
cargo bench --target wasm32-wasip1 --bench full_rlnc_encoder
before:
encode/1.0MB/16-pieces  time:   [2.1627 ms 2.1706 ms 2.1798 ms]
                        thrpt:  [487.44 MiB/s 489.52 MiB/s 491.29 MiB/s]
encode/1.0MB/32-pieces  time:   [2.3975 ms 2.5320 ms 2.6811 ms]
                        thrpt:  [384.66 MiB/s 407.31 MiB/s 430.16 MiB/s]
 after:
 encode/1.0MB/16-pieces  time:   [1.1017 ms 1.1120 ms 1.1242 ms]
                        thrpt:  [945.11 MiB/s 955.56 MiB/s 964.42 MiB/s]
 encode/1.0MB/32-pieces  time:   [1.1202 ms 1.1278 ms 1.1372 ms]
                        thrpt:  [906.85 MiB/s 914.45 MiB/s 920.67 MiB/s]
 