### PR TITLE
feat: type-safe, idiomatic Rust API (closes #20)

### DIFF
--- a/benches/full_rlnc_decoder.rs
+++ b/benches/full_rlnc_decoder.rs
@@ -102,19 +102,19 @@ fn decode(c: &mut Criterion) {
         let num_pieces_to_produce = rlnc_config.piece_count * 2;
         let coded_pieces = (0..num_pieces_to_produce).flat_map(|_| encoder.code(&mut rng)).collect::<Vec<u8>>();
 
-        let decoder = Decoder::new(encoder.get_piece_byte_len(), encoder.get_piece_count()).expect("Failed to create RLNC decoder");
+        let decoder = Decoder::new(encoder.piece_byte_len(), encoder.piece_count());
 
         group.measurement_time(Duration::from_secs(20));
         group.sample_size(100);
 
         group.throughput(Throughput::Bytes(
-            (decoder.get_full_coded_piece_byte_len() * decoder.get_num_pieces_coded_together()) as u64,
+            (decoder.full_coded_piece_byte_len() * decoder.piece_count().value()) as u64,
         ));
         group.bench_function(format!("{:?}", rlnc_config), move |b| {
             b.iter_batched(
                 || decoder.clone(),
                 |mut dec| {
-                    let mut coded_pieces_iter = coded_pieces.chunks_exact(dec.get_full_coded_piece_byte_len());
+                    let mut coded_pieces_iter = coded_pieces.chunks_exact(dec.full_coded_piece_byte_len());
 
                     while !black_box(&dec).is_already_decoded() {
                         let coded_piece = unsafe { coded_pieces_iter.next().unwrap_unchecked() };

--- a/benches/full_rlnc_encoder.rs
+++ b/benches/full_rlnc_encoder.rs
@@ -103,7 +103,7 @@ fn encode(c: &mut Criterion) {
 
         // Number of bytes used as input to encoder + Number of bytes for each coded piece
         group.throughput(Throughput::Bytes(
-            (encoder.get_piece_byte_len() * encoder.get_piece_count() + encoder.get_full_coded_piece_byte_len()) as u64,
+            (encoder.piece_byte_len().value() * encoder.piece_count().value() + encoder.full_coded_piece_byte_len()) as u64,
         ));
         group.bench_function(format!("{:?}", rlnc_config), move |b| {
             b.iter(|| black_box(&encoder).code(black_box(&mut rng)));
@@ -121,14 +121,14 @@ fn encode_zero_alloc(c: &mut Criterion) {
         let data = (0..rlnc_config.data_byte_len).map(|_| rng.random()).collect::<Vec<u8>>();
 
         let encoder = Encoder::new(data, rlnc_config.piece_count).expect("Failed to create RLNC encoder");
-        let mut full_coded_piece = vec![0u8; encoder.get_full_coded_piece_byte_len()];
+        let mut full_coded_piece = vec![0u8; encoder.full_coded_piece_byte_len()];
 
         group.measurement_time(Duration::from_secs(20));
         group.sample_size(100);
 
         // Number of bytes used as input to encoder + Number of bytes for each coded piece
         group.throughput(Throughput::Bytes(
-            (encoder.get_piece_byte_len() * encoder.get_piece_count() + encoder.get_full_coded_piece_byte_len()) as u64,
+            (encoder.piece_byte_len().value() * encoder.piece_count().value() + encoder.full_coded_piece_byte_len()) as u64,
         ));
         group.bench_function(format!("{:?}", rlnc_config), move |b| {
             b.iter(|| black_box(&encoder).code_with_buf(black_box(&mut rng), black_box(&mut full_coded_piece)));

--- a/benches/full_rlnc_recoder.rs
+++ b/benches/full_rlnc_recoder.rs
@@ -124,14 +124,14 @@ fn recode(c: &mut Criterion) {
             .flat_map(|_| encoder.code(&mut rng))
             .collect::<Vec<u8>>();
         let mut recoder =
-            Recoder::new(coded_pieces.clone(), encoder.get_full_coded_piece_byte_len(), encoder.get_piece_count()).expect("Failed to create RLNC recoder");
+            Recoder::new(coded_pieces.clone(), encoder.piece_byte_len(), encoder.piece_count()).expect("Failed to create RLNC recoder");
 
         group.measurement_time(Duration::from_secs(20));
         group.sample_size(100);
 
         // Number of bytes used as input to recoder + Number of bytes for each recoded piece
         group.throughput(Throughput::Bytes(
-            (recoder.get_full_coded_piece_byte_len() * recoder.get_num_pieces_recoded_together() + recoder.get_full_coded_piece_byte_len()) as u64,
+            (recoder.full_coded_piece_byte_len() * recoder.recoded_piece_count() + recoder.full_coded_piece_byte_len()) as u64,
         ));
         group.bench_function(format!("{:?}", rlnc_config), move |b| {
             b.iter(|| black_box(&mut recoder).recode(black_box(&mut rng)));
@@ -154,16 +154,16 @@ fn recode_zero_alloc(c: &mut Criterion) {
             .flat_map(|_| encoder.code(&mut rng))
             .collect::<Vec<u8>>();
         let mut recoder =
-            Recoder::new(coded_pieces.clone(), encoder.get_full_coded_piece_byte_len(), encoder.get_piece_count()).expect("Failed to create RLNC recoder");
+            Recoder::new(coded_pieces.clone(), encoder.piece_byte_len(), encoder.piece_count()).expect("Failed to create RLNC recoder");
 
-        let mut full_recoded_piece = vec![0u8; recoder.get_full_coded_piece_byte_len()];
+        let mut full_recoded_piece = vec![0u8; recoder.full_coded_piece_byte_len()];
 
         group.measurement_time(Duration::from_secs(20));
         group.sample_size(100);
 
         // Number of bytes used as input to recoder + Number of bytes for each recoded piece
         group.throughput(Throughput::Bytes(
-            (recoder.get_full_coded_piece_byte_len() * recoder.get_num_pieces_recoded_together() + recoder.get_full_coded_piece_byte_len()) as u64,
+            (recoder.full_coded_piece_byte_len() * recoder.recoded_piece_count() + recoder.full_coded_piece_byte_len()) as u64,
         ));
         group.bench_function(format!("{:?}", rlnc_config), move |b| {
             b.iter(|| black_box(&mut recoder).recode_with_buf(black_box(&mut rng), black_box(&mut full_recoded_piece)));

--- a/examples/full_rlnc.rs
+++ b/examples/full_rlnc.rs
@@ -19,24 +19,24 @@ fn main() {
         "Initialized Encoder with {} bytes of data, split into {} pieces, each of {} bytes. Each coded piece will be of {} bytes.",
         original_data_len,
         piece_count,
-        encoder.get_piece_byte_len(),
-        encoder.get_full_coded_piece_byte_len()
+        encoder.piece_byte_len().value(),
+        encoder.full_coded_piece_byte_len()
     );
 
-    // Show the overhead of encodng as a % on top of the original data size
-    let overhead = (encoder.get_full_coded_piece_byte_len() * piece_count) as f64 / original_data_len as f64 * 100.0 - 100.0;
+    // Show the overhead of encoding as a % on top of the original data size
+    let overhead = (encoder.full_coded_piece_byte_len() * piece_count) as f64 / original_data_len as f64 * 100.0 - 100.0;
     println!("Overhead of encoding: {overhead:.2}%");
 
     // 3. Initialize the Decoder
     println!(
         "Initializing Decoder, expecting {} original pieces of {} bytes each.",
-        encoder.get_piece_count(),
-        encoder.get_piece_byte_len()
+        encoder.piece_count().value(),
+        encoder.piece_byte_len().value()
     );
-    let mut decoder = Decoder::new(encoder.get_piece_byte_len(), encoder.get_piece_count()).expect("Failed to create RLNC decoder");
+    let mut decoder = Decoder::new(encoder.piece_byte_len(), encoder.piece_count());
 
     // 4. Simulate a sender generating initial coded pieces
-    let num_initial_coded_pieces_from_sender = encoder.get_piece_count() / 2; // Send half directly
+    let num_initial_coded_pieces_from_sender = encoder.piece_count().value() / 2; // Send half directly
     println!("\nSender generating {num_initial_coded_pieces_from_sender} initial coded pieces...");
     let mut pieces_for_recoder = Vec::new();
 
@@ -58,11 +58,11 @@ fn main() {
     // 5. Initialize the Recoder with same coded pieces which were already used for decoding
     println!("\nInitializing Recoder with {} bytes of received coded pieces.", pieces_for_recoder.len());
     let mut recoder =
-        Recoder::new(pieces_for_recoder, encoder.get_full_coded_piece_byte_len(), encoder.get_piece_count()).expect("Failed to create RLNC recoder");
+        Recoder::new(pieces_for_recoder, encoder.piece_byte_len(), encoder.piece_count()).expect("Failed to create RLNC recoder");
 
     // 6. Generate recoded pieces and feed them to the decoder, though all of the recoded pieces will be linearly dependent on the original pieces
     println!("\nRecoder active. Generating recoded pieces...");
-    let num_recoded_pieces_to_send = encoder.get_piece_count() * 2; // Send many recoded pieces, though all of them will be useless
+    let num_recoded_pieces_to_send = encoder.piece_count().value() * 2; // Send many recoded pieces, though all of them will be useless
 
     for i in 0..num_recoded_pieces_to_send {
         // This condition will never be executed because the decoder will not see a single useful coded piece while executing inside this loop
@@ -96,7 +96,7 @@ fn main() {
         pieces_for_new_recoder.len()
     );
     let mut recoder =
-        Recoder::new(pieces_for_new_recoder, encoder.get_full_coded_piece_byte_len(), encoder.get_piece_count()).expect("Must be able to build a new recoder");
+        Recoder::new(pieces_for_new_recoder, encoder.piece_byte_len(), encoder.piece_count()).expect("Must be able to build a new recoder");
 
     // 8. Generate new recoded pieces and feed them to the decoder. Now most of these recoded pieces will be useful, as these pieces were never seen by the decoder before.
     let num_recoded_pieces_to_send = num_initial_coded_pieces_from_sender / 2; // Send some recoded pieces for decoding
@@ -141,11 +141,11 @@ fn main() {
         }
     }
 
-    // 8. Retrieve the decoded data
+    // 10. Retrieve the decoded data
     println!("\nRetrieving decoded data...");
-    let decoded_data = decoder.get_decoded_data().expect("Failed to retrieve decoded data after all pieces received");
+    let decoded_data = decoder.into_decoded_data().expect("Failed to retrieve decoded data after all pieces received");
 
-    // 9. Verify that the decoded data matches the original data
+    // 11. Verify that the decoded data matches the original data
     assert_eq!(original_data_copy, decoded_data);
     println!("\nRLNC workflow completed successfully! Original data matches decoded data.");
 }

--- a/src/common/errors.rs
+++ b/src/common/errors.rs
@@ -9,13 +9,9 @@ pub enum RLNCError {
     PieceCountZero,
     /// When the data length is zero.
     DataLengthZero,
-    /// When the piece length is zero.
-    PieceLengthZero,
 
     /// When there are not enough linearly independent pieces available to perform recoding.
     NotEnoughPiecesToRecode,
-    /// When the full coded piece byte length is less than or equal to the number of pieces coded together.
-    PieceLengthTooShort,
 
     /// When a received piece does not provide new linearly independent information.
     PieceNotUseful,
@@ -39,11 +35,9 @@ impl std::fmt::Display for RLNCError {
             RLNCError::DataLengthMismatch => write!(f, "Data length mismatch"),
             RLNCError::PieceCountZero => write!(f, "Piece count is zero"),
             RLNCError::DataLengthZero => write!(f, "Data length is zero"),
-            RLNCError::PieceLengthZero => write!(f, "Piece length is zero"),
 
             // Recoder
             RLNCError::NotEnoughPiecesToRecode => write!(f, "Not enough pieces received to recode"),
-            RLNCError::PieceLengthTooShort => write!(f, "Piece length is too short"),
 
             // Decoder
             RLNCError::PieceNotUseful => write!(f, "Received piece is not useful"),

--- a/src/common/gf256.rs
+++ b/src/common/gf256.rs
@@ -65,7 +65,7 @@ impl Gf256 {
     }
 
     /// Returns the raw u8 value of the Gf256 element.
-    pub const fn get(&self) -> u8 {
+    pub const fn value(&self) -> u8 {
         self.val
     }
 

--- a/src/full/decoder.rs
+++ b/src/full/decoder.rs
@@ -1,4 +1,5 @@
 use super::consts::BOUNDARY_MARKER;
+use super::types::{PieceByteLen, PieceCount};
 use crate::{RLNCError, full::decoder_matrix::DecoderMatrix};
 
 /// Random Linear Network Coding (RLNC) Decoder.
@@ -22,61 +23,55 @@ pub struct Decoder {
 
 impl Decoder {
     /// Number of pieces original data got split into and coded together.
-    pub fn get_num_pieces_coded_together(&self) -> usize {
-        self.required_piece_count
+    pub fn piece_count(&self) -> PieceCount {
+        unsafe { PieceCount::new(self.required_piece_count).unwrap_unchecked() }
     }
 
-    /// After padding the original data, it gets split into `self.get_num_pieces_coded_together()` many pieces, which results into these many bytes per piece.
-    pub fn get_piece_byte_len(&self) -> usize {
-        self.piece_byte_len
+    /// After padding the original data, it gets split into `self.piece_count()` many pieces, which results into these many bytes per piece.
+    pub fn piece_byte_len(&self) -> PieceByteLen {
+        unsafe { PieceByteLen::new(self.piece_byte_len).unwrap_unchecked() }
     }
 
-    /// Each full coded piece consists of `self.get_num_pieces_coded_together()` random coefficients, appended by corresponding encoded piece of `self.get_piece_byte_len()` bytes.
-    pub fn get_full_coded_piece_byte_len(&self) -> usize {
-        self.get_num_pieces_coded_together() + self.get_piece_byte_len()
+    /// Each full coded piece consists of `self.piece_count()` random coefficients, appended by corresponding encoded piece of `self.piece_byte_len()` bytes.
+    pub fn full_coded_piece_byte_len(&self) -> usize {
+        self.required_piece_count + self.piece_byte_len
     }
 
     /// Total number of pieces received by the decoder so far.
-    pub fn get_received_piece_count(&self) -> usize {
+    pub fn received_piece_count(&self) -> usize {
         self.received_piece_count
     }
 
     /// Number of useful pieces received by the decoder so far.
-    pub fn get_useful_piece_count(&self) -> usize {
+    pub fn useful_piece_count(&self) -> usize {
         self.useful_piece_count
     }
 
     /// Number of pieces remaining to be received by the decoder for successful decoding.
-    pub fn get_remaining_piece_count(&self) -> usize {
-        self.get_num_pieces_coded_together() - self.get_useful_piece_count()
+    pub fn remaining_piece_count(&self) -> usize {
+        self.required_piece_count - self.useful_piece_count
     }
 
     /// Creates a new `Decoder` instance.
     ///
+    /// Because `PieceByteLen` and `PieceCount` are guaranteed to be non-zero by
+    /// construction, this function is infallible.
+    ///
     /// # Arguments
     /// * `piece_byte_len` - The byte length of each original data piece.
-    /// * `required_piece_count` - The minimum number of useful coded pieces
+    /// * `piece_count` - The minimum number of useful coded pieces
     ///   needed for decoding (equivalent to the number of original pieces).
-    ///
-    /// # Returns
-    /// * Returns `Ok(Decoder)` on successful creation.
-    /// * Returns `Err(RLNCError::PieceLengthZero)` if `piece_byte_len` is zero.
-    /// * Returns `Err(RLNCError::PieceCountZero)` if `required_piece_count` is zero.
-    pub fn new(piece_byte_len: usize, required_piece_count: usize) -> Result<Decoder, RLNCError> {
-        if piece_byte_len == 0 {
-            return Err(RLNCError::PieceLengthZero);
-        }
-        if required_piece_count == 0 {
-            return Err(RLNCError::PieceCountZero);
-        }
+    pub fn new(piece_byte_len: PieceByteLen, piece_count: PieceCount) -> Decoder {
+        let pbl = piece_byte_len.value();
+        let pc = piece_count.value();
 
-        Ok(Decoder {
-            matrix: DecoderMatrix::new(required_piece_count, piece_byte_len),
-            piece_byte_len,
-            required_piece_count,
+        Decoder {
+            matrix: DecoderMatrix::new(pc, pbl),
+            piece_byte_len: pbl,
+            required_piece_count: pc,
             received_piece_count: 0,
             useful_piece_count: 0,
-        })
+        }
     }
 
     /// Decodes a single full coded piece and adds it to the decoder's matrix.
@@ -97,7 +92,7 @@ impl Decoder {
         if self.is_already_decoded() {
             return Err(RLNCError::ReceivedAllPieces);
         }
-        if full_coded_piece.len() != self.get_full_coded_piece_byte_len() {
+        if full_coded_piece.len() != self.full_coded_piece_byte_len() {
             return Err(RLNCError::InvalidPieceLength);
         }
 
@@ -133,7 +128,7 @@ impl Decoder {
     /// * Returns `Ok(Vec<u8>)` containing the decoded data if successful.
     /// * Returns `Err(RLNCError::NotAllPiecesReceivedYet)` if not enough useful pieces have been received.
     /// * Returns `Err(RLNCError::InvalidDecodedDataFormat)` if the extracted data does not follow the expected format (e.g., boundary marker issues).
-    pub fn get_decoded_data(self) -> Result<Vec<u8>, RLNCError> {
+    pub fn into_decoded_data(self) -> Result<Vec<u8>, RLNCError> {
         if !self.is_already_decoded() {
             return Err(RLNCError::NotAllPiecesReceivedYet);
         }
@@ -142,7 +137,7 @@ impl Decoder {
         let mut buf = vec![0u8; required_len];
 
         let mut current_pos = 0;
-        let full_coded_piece_len = self.get_full_coded_piece_byte_len();
+        let full_coded_piece_len = self.full_coded_piece_byte_len();
 
         // Write the decoded data piece by piece into the output buffer
         for chunk in self.matrix.extract_data().chunks_exact(full_coded_piece_len) {
@@ -179,44 +174,22 @@ impl Decoder {
 
 #[cfg(test)]
 mod tests {
-    use super::{Decoder, RLNCError};
+    use super::{Decoder, PieceByteLen, PieceCount, RLNCError};
     use crate::full::encoder::Encoder;
     use rand::Rng;
 
     #[test]
-    fn test_decoder_new_invalid_inputs() {
-        // Test case 1: piece_byte_len is zero
-        let piece_byte_len_zero = 0;
-        let required_piece_count_non_zero = 10;
+    fn test_decoder_new_type_safety() {
+        // PieceByteLen and PieceCount reject zero at the type level
+        assert!(PieceByteLen::new(0).is_none());
+        assert!(PieceCount::new(0).is_none());
 
-        let result_piece_len_zero = Decoder::new(piece_byte_len_zero, required_piece_count_non_zero);
-        assert!(result_piece_len_zero.is_err());
-        assert_eq!(result_piece_len_zero.expect_err("Expected PieceLengthZero error"), RLNCError::PieceLengthZero);
-
-        // Test case 2: required_piece_count is zero
-        let piece_byte_len_non_zero = 10;
-        let required_piece_count_zero = 0;
-
-        let result_piece_count_zero = Decoder::new(piece_byte_len_non_zero, required_piece_count_zero);
-        assert!(result_piece_count_zero.is_err());
-        assert_eq!(result_piece_count_zero.expect_err("Expected PieceCountZero error"), RLNCError::PieceCountZero);
-
-        // Test case 3: Both piece_byte_len and required_piece_count are zero
-        let piece_byte_len_both_zero = 0;
-        let required_piece_count_both_zero = 0;
-
-        let result_both_zero = Decoder::new(piece_byte_len_both_zero, required_piece_count_both_zero);
-        assert!(result_both_zero.is_err());
-        assert_eq!(
-            result_both_zero.expect_err("Expected PieceLengthZero error for both zero inputs"),
-            RLNCError::PieceLengthZero
-        );
-
-        // Test case 4: Valid input
-        let piece_byte_len_valid = 10;
-        let required_piece_count_valid = 5;
-        let result_valid = Decoder::new(piece_byte_len_valid, required_piece_count_valid);
-        assert!(result_valid.is_ok());
+        // Valid input always succeeds (infallible constructor)
+        let piece_byte_len = PieceByteLen::new(10).unwrap();
+        let piece_count = PieceCount::new(5).unwrap();
+        let decoder = Decoder::new(piece_byte_len, piece_count);
+        assert_eq!(decoder.piece_count(), piece_count);
+        assert_eq!(decoder.piece_byte_len(), piece_byte_len);
     }
 
     #[test]
@@ -228,14 +201,10 @@ mod tests {
         let data = (0..data_byte_len).map(|_| rng.random()).collect::<Vec<u8>>();
         let encoder = Encoder::new(data, piece_count).expect("Failed to create Encoder for decode invalid length test");
 
-        let piece_byte_len = encoder.get_piece_byte_len();
-        let required_piece_count = encoder.get_piece_count();
-        let full_coded_piece_byte_len = encoder.get_full_coded_piece_byte_len();
-
-        let mut decoder = Decoder::new(piece_byte_len, required_piece_count).expect("Failed to create Decoder for decode invalid length test");
+        let mut decoder = Decoder::new(encoder.piece_byte_len(), encoder.piece_count());
 
         // Test case 1: Piece length is shorter than expected
-        let short_piece_len = full_coded_piece_byte_len - 1;
+        let short_piece_len = encoder.full_coded_piece_byte_len() - 1;
         let short_coded_piece: Vec<u8> = (0..short_piece_len).map(|_| rng.random()).collect();
         let result_short = decoder.decode(&short_coded_piece);
         assert!(result_short.is_err());
@@ -245,7 +214,7 @@ mod tests {
         );
 
         // Test case 2: Piece length is longer than expected
-        let long_piece_len = full_coded_piece_byte_len + 1;
+        let long_piece_len = encoder.full_coded_piece_byte_len() + 1;
         let long_coded_piece: Vec<u8> = (0..long_piece_len).map(|_| rng.random()).collect();
         let result_long = decoder.decode(&long_coded_piece);
         assert!(result_long.is_err());
@@ -264,8 +233,8 @@ mod tests {
         );
 
         // Ensure decoder state is unchanged after invalid decode attempts
-        assert_eq!(decoder.get_received_piece_count(), 0);
-        assert_eq!(decoder.get_useful_piece_count(), 0);
+        assert_eq!(decoder.received_piece_count(), 0);
+        assert_eq!(decoder.useful_piece_count(), 0);
         assert!(!decoder.is_already_decoded());
 
         // Test case 4: Valid coded piece - check if state changes
@@ -274,15 +243,15 @@ mod tests {
         assert!(result_correct.is_ok() || matches!(result_correct, Err(RLNCError::PieceNotUseful)));
 
         // After a valid decode attempt, received_piece_count must increase
-        assert_eq!(decoder.get_received_piece_count(), 1);
+        assert_eq!(decoder.received_piece_count(), 1);
 
         // If the piece was useful, useful_piece_count will be 1. Otherwise, it remains 0.
         // Given the small piece_count in this test, it's very likely to be useful.
         if result_correct.is_ok() {
-            assert_eq!(decoder.get_useful_piece_count(), 1);
+            assert_eq!(decoder.useful_piece_count(), 1);
             assert!(!decoder.is_already_decoded()); // Unless piece_count was 1
         } else {
-            assert_eq!(decoder.get_useful_piece_count(), 0);
+            assert_eq!(decoder.useful_piece_count(), 0);
         }
     }
 
@@ -295,22 +264,18 @@ mod tests {
         let data = (0..data_byte_len).map(|_| rng.random()).collect::<Vec<u8>>();
         let encoder = Encoder::new(data.clone(), piece_count).expect("Failed to create Encoder for getters test");
 
-        let piece_byte_len = encoder.get_piece_byte_len();
-        let required_piece_count = encoder.get_piece_count();
-        let full_coded_piece_byte_len = encoder.get_full_coded_piece_byte_len();
+        let mut decoder = Decoder::new(encoder.piece_byte_len(), encoder.piece_count());
 
-        let mut decoder = Decoder::new(piece_byte_len, required_piece_count).expect("Failed to create Decoder for getters test");
-
-        assert_eq!(decoder.get_num_pieces_coded_together(), required_piece_count);
-        assert_eq!(decoder.get_piece_byte_len(), piece_byte_len);
-        assert_eq!(decoder.get_full_coded_piece_byte_len(), full_coded_piece_byte_len);
-        assert_eq!(decoder.get_received_piece_count(), 0);
-        assert_eq!(decoder.get_useful_piece_count(), 0);
-        assert_eq!(decoder.get_remaining_piece_count(), required_piece_count);
+        assert_eq!(decoder.piece_count(), encoder.piece_count());
+        assert_eq!(decoder.piece_byte_len(), encoder.piece_byte_len());
+        assert_eq!(decoder.full_coded_piece_byte_len(), encoder.full_coded_piece_byte_len());
+        assert_eq!(decoder.received_piece_count(), 0);
+        assert_eq!(decoder.useful_piece_count(), 0);
+        assert_eq!(decoder.remaining_piece_count(), encoder.piece_count().value());
         assert!(!decoder.is_already_decoded());
 
         // Add some pieces and track useful ones
-        let num_pieces_to_decode_initially = required_piece_count / 2;
+        let num_pieces_to_decode_initially = encoder.piece_count().value() / 2;
         let mut expected_useful_pieces_after_initial = 0;
 
         for _ in 0..num_pieces_to_decode_initially {
@@ -324,9 +289,9 @@ mod tests {
             }
         }
 
-        assert_eq!(decoder.get_received_piece_count(), num_pieces_to_decode_initially);
-        assert_eq!(decoder.get_useful_piece_count(), expected_useful_pieces_after_initial);
-        assert_eq!(decoder.get_remaining_piece_count(), required_piece_count - expected_useful_pieces_after_initial);
+        assert_eq!(decoder.received_piece_count(), num_pieces_to_decode_initially);
+        assert_eq!(decoder.useful_piece_count(), expected_useful_pieces_after_initial);
+        assert_eq!(decoder.remaining_piece_count(), encoder.piece_count().value() - expected_useful_pieces_after_initial);
 
         // Add remaining pieces to complete decoding
         let mut total_pieces_received = num_pieces_to_decode_initially;
@@ -343,9 +308,9 @@ mod tests {
             total_pieces_received += 1;
         }
 
-        assert_eq!(decoder.get_useful_piece_count(), required_piece_count);
-        assert_eq!(decoder.get_remaining_piece_count(), 0);
+        assert_eq!(decoder.useful_piece_count(), encoder.piece_count().value());
+        assert_eq!(decoder.remaining_piece_count(), 0);
         assert!(decoder.is_already_decoded());
-        assert_eq!(decoder.get_received_piece_count(), total_pieces_received);
+        assert_eq!(decoder.received_piece_count(), total_pieces_received);
     }
 }

--- a/src/full/decoder_matrix.rs
+++ b/src/full/decoder_matrix.rs
@@ -145,7 +145,7 @@ impl DecoderMatrix {
                     continue;
                 }
 
-                let quotient = unsafe { (self[(j, i)] / self[(i, i)]).unwrap_unchecked().get() };
+                let quotient = unsafe { (self[(j, i)] / self[(i, i)]).unwrap_unchecked().value() };
 
                 let i_th_row_starts_at = i * self.cols;
                 let i_th_row_ends_at = i_th_row_starts_at + self.cols;
@@ -181,7 +181,7 @@ impl DecoderMatrix {
                     continue;
                 }
 
-                let quotient = unsafe { (self[(j, i)] / self[(i, i)]).unwrap_unchecked().get() };
+                let quotient = unsafe { (self[(j, i)] / self[(i, i)]).unwrap_unchecked().value() };
 
                 let j_th_row_starts_at = j * self.cols;
                 let j_th_row_ends_at = j_th_row_starts_at + self.cols;
@@ -201,7 +201,7 @@ impl DecoderMatrix {
                 continue;
             }
 
-            let inv = unsafe { self[(i, i)].inv().unwrap_unchecked().get() };
+            let inv = unsafe { self[(i, i)].inv().unwrap_unchecked().value() };
             self[(i, i)] = Gf256::one();
 
             let i_th_row_starts_at = i * self.cols;

--- a/src/full/encoder.rs
+++ b/src/full/encoder.rs
@@ -1,4 +1,5 @@
 use super::consts::BOUNDARY_MARKER;
+use super::types::{PieceByteLen, PieceCount};
 use crate::RLNCError;
 use rand::Rng;
 
@@ -24,18 +25,18 @@ pub struct Encoder {
 
 impl Encoder {
     /// Number of pieces original data got split into and being coded together.
-    pub fn get_piece_count(&self) -> usize {
-        self.piece_count
+    pub fn piece_count(&self) -> PieceCount {
+        unsafe { PieceCount::new(self.piece_count).unwrap_unchecked() }
     }
 
-    /// After padding the original data, it gets split into `self.get_piece_count()` many pieces, which results into these many bytes per piece.
-    pub fn get_piece_byte_len(&self) -> usize {
-        self.piece_byte_len
+    /// After padding the original data, it gets split into `self.piece_count()` many pieces, which results into these many bytes per piece.
+    pub fn piece_byte_len(&self) -> PieceByteLen {
+        unsafe { PieceByteLen::new(self.piece_byte_len).unwrap_unchecked() }
     }
 
-    /// Each full coded piece consists of `self.get_piece_count()` random coefficients, appended by corresponding encoded piece of `self.get_piece_byte_len()` bytes.
-    pub fn get_full_coded_piece_byte_len(&self) -> usize {
-        self.get_piece_count() + self.get_piece_byte_len()
+    /// Each full coded piece consists of `self.piece_count()` random coefficients, appended by corresponding encoded piece of `self.piece_byte_len()` bytes.
+    pub fn full_coded_piece_byte_len(&self) -> usize {
+        self.piece_count + self.piece_byte_len
     }
 
     /// Creates a new `Encoder` without adding any padding to the input data.
@@ -109,7 +110,7 @@ impl Encoder {
     /// is used by the Recoder, to avoid any memory allocation during recoding.
     ///
     /// The output buffer `coded_data` will contain only coded data portion of the
-    /// full erasure-coded piece. Its length must be equal to `self.get_piece_byte_len()`.
+    /// full erasure-coded piece. Its length must be equal to `self.piece_byte_len()`.
     /// It's caller responsibility to fill `coding_vector` with random coding coefficients.
     ///
     /// This implementation might benefit from SIMD assisted fast GF(2^8) arithmetic on some targets
@@ -122,8 +123,8 @@ impl Encoder {
     ///
     /// # Returns
     /// * Returns `Ok(())` on success.
-    /// * Returns `Err(RLNCError::CodingVectorLengthMismatch)` if the length of `coding_vector` is not `self.get_piece_count()`.
-    /// * Returns `Err(RLNCError::InvalidOutputBuffer)` if the length of `coded_data` is not `self.get_piece_byte_len()`.
+    /// * Returns `Err(RLNCError::CodingVectorLengthMismatch)` if the length of `coding_vector` is not `self.piece_count()`.
+    /// * Returns `Err(RLNCError::InvalidOutputBuffer)` if the length of `coded_data` is not `self.piece_byte_len()`.
     #[cfg(not(feature = "parallel"))]
     pub(crate) fn code_with_coding_vector(&self, coding_vector: &[u8], coded_data: &mut [u8]) -> Result<(), RLNCError> {
         if coding_vector.len() != self.piece_count {
@@ -147,7 +148,7 @@ impl Encoder {
     /// is used by the Recoder, to avoid any memory allocation during recoding.
     ///
     /// The output buffer `coded_data` will contain only coded data portion of the
-    /// full erasure-coded piece. Its length must be equal to `self.get_piece_byte_len()`.
+    /// full erasure-coded piece. Its length must be equal to `self.piece_byte_len()`.
     /// It's caller responsibility to fill `coding_vector` with random coding coefficients.
     ///
     /// This implementation uses `rayon` data-parallelism for fast erasure-coding. One might
@@ -161,8 +162,8 @@ impl Encoder {
     ///
     /// # Returns
     /// * Returns `Ok(())` on success.
-    /// * Returns `Err(RLNCError::CodingVectorLengthMismatch)` if the length of `coding_vector` is not `self.get_piece_count()`.
-    /// * Returns `Err(RLNCError::InvalidOutputBuffer)` if the length of `coded_data` is not `self.get_piece_byte_len()`.
+    /// * Returns `Err(RLNCError::CodingVectorLengthMismatch)` if the length of `coding_vector` is not `self.piece_count()`.
+    /// * Returns `Err(RLNCError::InvalidOutputBuffer)` if the length of `coded_data` is not `self.piece_byte_len()`.
     #[cfg(feature = "parallel")]
     pub(crate) fn code_with_coding_vector(&self, coding_vector: &[u8], coded_data: &mut [u8]) -> Result<(), RLNCError> {
         if coding_vector.len() != self.piece_count {
@@ -188,7 +189,7 @@ impl Encoder {
 
                     #[cfg(not(any(target_arch = "x86", target_arch = "x86_64", target_arch = "aarch64")))]
                     {
-                        piece.iter().map(move |&symbol| (Gf256::new(symbol) * Gf256::new(random_symbol)).get())
+                        piece.iter().map(move |&symbol| (Gf256::new(symbol) * Gf256::new(random_symbol)).value())
                     }
                 })
                 .fold(
@@ -229,7 +230,7 @@ impl Encoder {
     ///
     /// The output buffer `full_coded_piece` will contain the random sampled
     /// coding vector followed by the coded data. The length of `full_coded_piece`
-    /// must be equal to `self.get_full_coded_piece_byte_len()`.
+    /// must be equal to `self.full_coded_piece_byte_len()`.
     ///
     /// # Arguments
     /// * `rng` - A mutable reference to a random number generator.
@@ -239,7 +240,7 @@ impl Encoder {
     /// * Returns `Ok(())` on success.
     /// * Returns `Err(RLNCError::InvalidOutputBuffer)` if the length of `full_coded_piece` is incorrect.
     pub fn code_with_buf<R: Rng + ?Sized>(&self, rng: &mut R, full_coded_piece: &mut [u8]) -> Result<(), RLNCError> {
-        if full_coded_piece.len() != self.get_full_coded_piece_byte_len() {
+        if full_coded_piece.len() != self.full_coded_piece_byte_len() {
             return Err(RLNCError::InvalidOutputBuffer);
         }
 
@@ -260,9 +261,9 @@ impl Encoder {
     ///
     /// # Returns
     /// A `Vec<u8>` containing the random sampled coding vector followed by the
-    /// coded data. The length of the returned vector is `self.get_full_coded_piece_byte_len()`.
+    /// coded data. The length of the returned vector is `self.full_coded_piece_byte_len()`.
     pub fn code<R: Rng + ?Sized>(&self, rng: &mut R) -> Vec<u8> {
-        let mut full_coded_piece = vec![0u8; self.get_full_coded_piece_byte_len()];
+        let mut full_coded_piece = vec![0u8; self.full_coded_piece_byte_len()];
         unsafe { self.code_with_buf(rng, &mut full_coded_piece).unwrap_unchecked() };
 
         full_coded_piece
@@ -271,7 +272,7 @@ impl Encoder {
 
 #[cfg(test)]
 mod tests {
-    use super::{Encoder, RLNCError};
+    use super::{Encoder, PieceByteLen, PieceCount, RLNCError};
     use rand::Rng;
 
     #[test]
@@ -367,8 +368,8 @@ mod tests {
         let encoder = Encoder::new(data, piece_count).expect("Failed to create Encoder for invalid inputs test");
 
         // Test case 1: Coding vector is shorter than expected
-        let short_coding_vector: Vec<u8> = (0..(encoder.get_piece_count() - 1)).map(|_| rng.random()).collect();
-        let mut coded_data = vec![0u8; encoder.get_piece_byte_len()];
+        let short_coding_vector: Vec<u8> = (0..(encoder.piece_count().value() - 1)).map(|_| rng.random()).collect();
+        let mut coded_data = vec![0u8; encoder.piece_byte_len().value()];
 
         let result_short = encoder.code_with_coding_vector(&short_coding_vector, &mut coded_data);
 
@@ -379,8 +380,8 @@ mod tests {
         );
 
         // Test case 2: Coded data buffer is shorter than expected
-        let coding_vector: Vec<u8> = (0..encoder.get_piece_count()).map(|_| rng.random()).collect();
-        let mut short_coded_data = vec![0u8; encoder.get_piece_byte_len() - 1];
+        let coding_vector: Vec<u8> = (0..encoder.piece_count().value()).map(|_| rng.random()).collect();
+        let mut short_coded_data = vec![0u8; encoder.piece_byte_len().value() - 1];
 
         let result_short = encoder.code_with_coding_vector(&coding_vector, &mut short_coded_data);
 
@@ -391,8 +392,8 @@ mod tests {
         );
 
         // Test case 3: Coding vector is longer than expected
-        let long_coding_vector: Vec<u8> = (0..(encoder.get_piece_count() + 1)).map(|_| rng.random()).collect();
-        let mut coded_data = vec![0u8; encoder.get_piece_byte_len()];
+        let long_coding_vector: Vec<u8> = (0..(encoder.piece_count().value() + 1)).map(|_| rng.random()).collect();
+        let mut coded_data = vec![0u8; encoder.piece_byte_len().value()];
 
         let result_long = encoder.code_with_coding_vector(&long_coding_vector, &mut coded_data);
 
@@ -403,8 +404,8 @@ mod tests {
         );
 
         // Test case 4: Coded data buffer is longer than expected
-        let coding_vector: Vec<u8> = (0..encoder.get_piece_count()).map(|_| rng.random()).collect();
-        let mut long_coded_data = vec![0u8; encoder.get_piece_byte_len() + 1];
+        let coding_vector: Vec<u8> = (0..encoder.piece_count().value()).map(|_| rng.random()).collect();
+        let mut long_coded_data = vec![0u8; encoder.piece_byte_len().value() + 1];
 
         let result_long = encoder.code_with_coding_vector(&coding_vector, &mut long_coded_data);
 
@@ -416,7 +417,7 @@ mod tests {
 
         // Test case 5: Empty coding vector
         let empty_coding_vector: Vec<u8> = vec![];
-        let mut coded_data = vec![0u8; encoder.get_full_coded_piece_byte_len()];
+        let mut coded_data = vec![0u8; encoder.full_coded_piece_byte_len()];
 
         let result_empty = encoder.code_with_coding_vector(&empty_coding_vector, &mut coded_data);
 
@@ -427,7 +428,7 @@ mod tests {
         );
 
         // Test case 6: Empty coding vector
-        let coding_vector: Vec<u8> = (0..encoder.get_piece_count()).map(|_| rng.random()).collect();
+        let coding_vector: Vec<u8> = (0..encoder.piece_count().value()).map(|_| rng.random()).collect();
         let mut empty_coded_data: Vec<u8> = vec![];
 
         let result_empty = encoder.code_with_coding_vector(&coding_vector, &mut empty_coded_data);
@@ -439,8 +440,8 @@ mod tests {
         );
 
         // Test case 7: Valid coding vector
-        let valid_coding_vector: Vec<u8> = (0..encoder.get_piece_count()).map(|_| rng.random()).collect();
-        let mut valid_coded_data = vec![0u8; encoder.get_piece_byte_len()];
+        let valid_coding_vector: Vec<u8> = (0..encoder.piece_count().value()).map(|_| rng.random()).collect();
+        let mut valid_coded_data = vec![0u8; encoder.piece_byte_len().value()];
 
         let result_valid = encoder.code_with_coding_vector(&valid_coding_vector, &mut valid_coded_data);
 
@@ -457,7 +458,7 @@ mod tests {
         let encoder = Encoder::new(data, piece_count).expect("Failed to create Encoder for invalid inputs test");
 
         // Test case 1: Coded piece buffer is shorter than expected
-        let mut short_coded_piece = vec![0u8; encoder.get_full_coded_piece_byte_len() - 1];
+        let mut short_coded_piece = vec![0u8; encoder.full_coded_piece_byte_len() - 1];
         let result_short = encoder.code_with_buf(&mut rng, &mut short_coded_piece);
 
         assert!(result_short.is_err());
@@ -467,7 +468,7 @@ mod tests {
         );
 
         // Test case 2: Coded piece buffer is longer than expected
-        let mut long_coded_piece = vec![0u8; encoder.get_full_coded_piece_byte_len() + 1];
+        let mut long_coded_piece = vec![0u8; encoder.full_coded_piece_byte_len() + 1];
         let result_long = encoder.code_with_buf(&mut rng, &mut long_coded_piece);
 
         assert!(result_long.is_err());
@@ -487,7 +488,7 @@ mod tests {
         );
 
         // Test case 4: Valid full coded piece buffer
-        let mut coded_piece = vec![0u8; encoder.get_full_coded_piece_byte_len()];
+        let mut coded_piece = vec![0u8; encoder.full_coded_piece_byte_len()];
         let result_valid = encoder.code_with_buf(&mut rng, &mut coded_piece);
 
         assert!(result_valid.is_ok());
@@ -503,10 +504,10 @@ mod tests {
         let data_single = (0..data_byte_len_single).map(|_| rng.random()).collect::<Vec<u8>>();
         let encoder_single = Encoder::new(data_single.clone(), piece_count_single).expect("Failed to create Encoder (single piece)");
 
-        assert_eq!(encoder_single.get_piece_count(), piece_count_single);
-        assert_eq!(encoder_single.get_piece_byte_len(), (data_byte_len_single + 1).div_ceil(piece_count_single));
+        assert_eq!(encoder_single.piece_count(), PieceCount::new(piece_count_single).unwrap());
+        assert_eq!(encoder_single.piece_byte_len(), PieceByteLen::new((data_byte_len_single + 1).div_ceil(piece_count_single)).unwrap());
         assert_eq!(
-            encoder_single.get_full_coded_piece_byte_len(),
+            encoder_single.full_coded_piece_byte_len(),
             piece_count_single + (data_byte_len_single + 1).div_ceil(piece_count_single)
         );
 
@@ -515,9 +516,9 @@ mod tests {
         let data_min = vec![42u8];
         let encoder_min = Encoder::new(data_min, piece_count_min).expect("Failed to create Encoder (min data)");
 
-        assert_eq!(encoder_min.get_piece_count(), piece_count_min);
-        assert_eq!(encoder_min.get_piece_byte_len(), 2); // 1 byte data + 1 boundary marker
-        assert_eq!(encoder_min.get_full_coded_piece_byte_len(), 3); // 1 coeff + 2 data bytes
+        assert_eq!(encoder_min.piece_count().value(), piece_count_min);
+        assert_eq!(encoder_min.piece_byte_len().value(), 2); // 1 byte data + 1 boundary marker
+        assert_eq!(encoder_min.full_coded_piece_byte_len(), 3); // 1 coeff + 2 data bytes
 
         // Test case 3: Data length equals piece count (each piece gets 1 data byte + padding)
         let data_byte_len_eq = 10usize;
@@ -525,9 +526,9 @@ mod tests {
         let data_eq = (0..data_byte_len_eq).map(|_| rng.random()).collect::<Vec<u8>>();
         let encoder_eq = Encoder::new(data_eq, piece_count_eq).expect("Failed to create Encoder (equal length)");
 
-        assert_eq!(encoder_eq.get_piece_count(), piece_count_eq);
-        assert_eq!(encoder_eq.get_piece_byte_len(), (data_byte_len_eq + 1).div_ceil(piece_count_eq)); // 2 bytes per piece
-        assert_eq!(encoder_eq.get_full_coded_piece_byte_len(), piece_count_eq + 2);
+        assert_eq!(encoder_eq.piece_count().value(), piece_count_eq);
+        assert_eq!(encoder_eq.piece_byte_len().value(), (data_byte_len_eq + 1).div_ceil(piece_count_eq)); // 2 bytes per piece
+        assert_eq!(encoder_eq.full_coded_piece_byte_len(), piece_count_eq + 2);
 
         // Test case 4: Large piece count (many small pieces)
         let data_byte_len_large = 100usize;
@@ -535,10 +536,10 @@ mod tests {
         let data_large = (0..data_byte_len_large).map(|_| rng.random()).collect::<Vec<u8>>();
         let encoder_large = Encoder::new(data_large, piece_count_large).expect("Failed to create Encoder (large piece count)");
 
-        assert_eq!(encoder_large.get_piece_count(), piece_count_large);
-        assert_eq!(encoder_large.get_piece_byte_len(), (data_byte_len_large + 1).div_ceil(piece_count_large));
+        assert_eq!(encoder_large.piece_count().value(), piece_count_large);
+        assert_eq!(encoder_large.piece_byte_len().value(), (data_byte_len_large + 1).div_ceil(piece_count_large));
         assert_eq!(
-            encoder_large.get_full_coded_piece_byte_len(),
+            encoder_large.full_coded_piece_byte_len(),
             piece_count_large + (data_byte_len_large + 1).div_ceil(piece_count_large)
         );
     }

--- a/src/full/mod.rs
+++ b/src/full/mod.rs
@@ -3,9 +3,11 @@ mod decoder;
 mod decoder_matrix;
 mod encoder;
 mod recoder;
+mod types;
 
 mod tests;
 
 pub use decoder::Decoder;
 pub use encoder::Encoder;
 pub use recoder::Recoder;
+pub use types::{PieceByteLen, PieceCount};

--- a/src/full/recoder.rs
+++ b/src/full/recoder.rs
@@ -1,4 +1,5 @@
 use super::encoder::Encoder;
+use super::types::{PieceByteLen, PieceCount};
 use crate::{RLNCError, common::gf256::Gf256};
 use rand::Rng;
 
@@ -23,28 +24,28 @@ pub struct Recoder {
 
 impl Recoder {
     /// Number of pieces original data got split into to be coded together.
-    pub fn get_original_num_pieces_coded_together(&self) -> usize {
-        self.num_pieces_coded_together
+    pub fn piece_count(&self) -> PieceCount {
+        unsafe { PieceCount::new(self.num_pieces_coded_together).unwrap_unchecked() }
     }
 
     /// Number of pieces received by Recoder, which is getting recoded together, producing new pieces.
-    pub fn get_num_pieces_recoded_together(&self) -> usize {
+    pub fn recoded_piece_count(&self) -> usize {
         self.num_pieces_received
     }
 
-    /// After padding the original data, it gets split into `self.get_original_num_pieces_coded_together()` many pieces, which results into these many bytes per piece.
-    pub fn get_piece_byte_len(&self) -> usize {
-        self.full_coded_piece_byte_len - self.num_pieces_coded_together
+    /// After padding the original data, it gets split into `self.piece_count()` many pieces, which results into these many bytes per piece.
+    pub fn piece_byte_len(&self) -> PieceByteLen {
+        unsafe { PieceByteLen::new(self.full_coded_piece_byte_len - self.num_pieces_coded_together).unwrap_unchecked() }
     }
 
-    /// Each full coded piece consists of `self.get_original_num_pieces_coded_together()` random coefficients, appended by corresponding encoded piece of `self.get_piece_byte_len()` bytes.
-    pub fn get_full_coded_piece_byte_len(&self) -> usize {
+    /// Each full coded piece consists of `self.piece_count()` random coefficients, appended by corresponding encoded piece of `self.piece_byte_len()` bytes.
+    pub fn full_coded_piece_byte_len(&self) -> usize {
         self.full_coded_piece_byte_len
     }
 
     /// Creates a new `Recoder` instance from a vector of received coded pieces.
     ///
-    /// Each full coded piece in `data` is of `full_coded_piece_byte_len` bytes.
+    /// Each full coded piece in `data` is of `piece_count + piece_byte_len` bytes.
     /// A full coded piece = coding vector ++ coded piece
     ///
     /// The `Recoder` extracts the coding vectors and coded pieces from the input
@@ -52,38 +53,27 @@ impl Recoder {
     /// represents the source pieces extracted from the input.
     ///
     /// # Arguments
-    /// * `data`: A vector of bytes containing the concatenated full coded pieces, each of
-    ///   `full_coded_piece_byte_len` bytes length.
-    /// * `full_coded_piece_byte_len`: The byte length of a full coded piece.
-    /// * `num_pieces_coded_together`: The number of original pieces that were
-    ///   linearly combined to create each coded piece. This is also the length
-    ///   of the coding vector prepended to each full coded piece.
+    /// * `data`: A vector of bytes containing the concatenated full coded pieces.
+    /// * `piece_byte_len`: The byte length of each coded data piece (excluding the coding vector).
+    /// * `piece_count`: The number of original pieces that were linearly combined
+    ///   to create each coded piece. This is also the length of the coding vector
+    ///   prepended to each full coded piece.
     ///
     /// # Returns
     /// * Returns `Ok(Recoder)` on successful creation.
-    /// * Returns `Err(RLNCError::NotEnoughPiecesToRecode)` if the input `data` is empty or does not contain at least one full coded piece.
-    /// * Returns `Err(RLNCError::PieceLengthZero)` if `full_coded_piece_byte_len` is zero.
-    /// * Returns `Err(RLNCError::PieceCountZero)` if `num_pieces_coded_together` is zero.
-    /// * Returns `Err(RLNCError::PieceLengthTooShort)` if `full_coded_piece_byte_len` is not greater than `num_pieces_coded_together`.
-    pub fn new(data: Vec<u8>, full_coded_piece_byte_len: usize, num_pieces_coded_together: usize) -> Result<Recoder, RLNCError> {
-        if data.is_empty() {
+    /// * Returns `Err(RLNCError::NotEnoughPiecesToRecode)` if the input `data` does not contain at least one full coded piece.
+    pub fn new(data: Vec<u8>, piece_byte_len: PieceByteLen, piece_count: PieceCount) -> Result<Recoder, RLNCError> {
+        let num_pieces_coded_together = piece_count.value();
+        let pbl = piece_byte_len.value();
+        let full_coded_piece_byte_len = num_pieces_coded_together + pbl;
+
+        let num_pieces_received = data.len() / full_coded_piece_byte_len;
+        if num_pieces_received == 0 {
             return Err(RLNCError::NotEnoughPiecesToRecode);
         }
-        if full_coded_piece_byte_len == 0 {
-            return Err(RLNCError::PieceLengthZero);
-        }
-        if num_pieces_coded_together == 0 {
-            return Err(RLNCError::PieceCountZero);
-        }
-        if full_coded_piece_byte_len <= num_pieces_coded_together {
-            return Err(RLNCError::PieceLengthTooShort);
-        }
-
-        let piece_byte_len = full_coded_piece_byte_len - num_pieces_coded_together;
-        let num_pieces_received = data.len() / full_coded_piece_byte_len;
 
         let mut coding_vectors = Vec::with_capacity(num_pieces_received * num_pieces_coded_together);
-        let mut coded_pieces = Vec::with_capacity(num_pieces_received * piece_byte_len);
+        let mut coded_pieces = Vec::with_capacity(num_pieces_received * pbl);
 
         data.chunks_exact(full_coded_piece_byte_len).for_each(|full_coded_piece| {
             let coding_vector = &full_coded_piece[..num_pieces_coded_together];
@@ -110,7 +100,7 @@ impl Recoder {
     /// Produces a new coded piece by recoding the source pieces, random sampling coding coefficients
     /// and writing full coded piece into the provided buffer. The output buffer contains the
     /// computed source coding vector followed by the coded data. The length of `full_recoded_piece`
-    /// must be equal to `self.get_full_coded_piece_byte_len()`.
+    /// must be equal to `self.full_coded_piece_byte_len()`.
     ///
     /// # Arguments
     /// * `rng`: Used to sample the random recoding vector.
@@ -140,7 +130,7 @@ impl Recoder {
                     acc + Gf256::new(cur) * self.coding_vectors[row_begins_at + coeff_idx]
                 });
 
-            *coeff_val = computed_coeff.get();
+            *coeff_val = computed_coeff.value();
         }
 
         unsafe {
@@ -162,9 +152,9 @@ impl Recoder {
     ///
     /// # Returns
     /// A `Vec<u8>` representing the new coded piece prepended with its source coding vector.
-    /// The length of the returned vector is `self.get_full_coded_piece_byte_len()`.
+    /// The length of the returned vector is `self.full_coded_piece_byte_len()`.
     pub fn recode<R: Rng + ?Sized>(&mut self, rng: &mut R) -> Vec<u8> {
-        let mut full_recoded_piece = vec![0u8; self.get_full_coded_piece_byte_len()];
+        let mut full_recoded_piece = vec![0u8; self.full_coded_piece_byte_len()];
         unsafe { self.recode_with_buf(rng, &mut full_recoded_piece).unwrap_unchecked() }
 
         full_recoded_piece
@@ -185,69 +175,34 @@ mod tests {
         let piece_count = 32usize;
         let encoder = Encoder::new((0..data_byte_len).map(|_| rng.random()).collect::<Vec<u8>>(), piece_count)
             .expect("Failed to create Encoder for recoder new invalid inputs test");
-        let full_coded_piece_byte_len = encoder.get_full_coded_piece_byte_len();
-        let num_pieces_coded_together = encoder.get_piece_count();
 
         // Test case 1: Empty `data` vector
         let empty_data: Vec<u8> = Vec::new();
-        let result_empty_data = Recoder::new(empty_data, full_coded_piece_byte_len, num_pieces_coded_together);
+        let result_empty_data = Recoder::new(empty_data, encoder.piece_byte_len(), encoder.piece_count());
         assert!(result_empty_data.is_err());
         assert_eq!(
             result_empty_data.expect_err("Expected NotEnoughPiecesToRecode error for empty data"),
             RLNCError::NotEnoughPiecesToRecode
         );
 
-        // Test case 2: `full_coded_piece_byte_len` is zero
-        let data_non_empty = vec![1, 2, 3]; // Needs at least one piece worth of data for non-empty input
-        let result_zero_full_len = Recoder::new(data_non_empty.clone(), 0, num_pieces_coded_together);
-        assert!(result_zero_full_len.is_err());
+        // Test case 2: Data shorter than one full coded piece
+        let short_data = vec![1u8; encoder.full_coded_piece_byte_len() - 1];
+        let result_short = Recoder::new(short_data, encoder.piece_byte_len(), encoder.piece_count());
+        assert!(result_short.is_err());
         assert_eq!(
-            result_zero_full_len.expect_err("Expected PieceLengthZero error for zero full coded piece length"),
-            RLNCError::PieceLengthZero
+            result_short.expect_err("Expected NotEnoughPiecesToRecode error for short data"),
+            RLNCError::NotEnoughPiecesToRecode
         );
 
-        // Test case 3: `num_pieces_coded_together` is zero
-        let result_zero_piece_count = Recoder::new(data_non_empty.clone(), full_coded_piece_byte_len, 0);
-        assert!(result_zero_piece_count.is_err());
-        assert_eq!(
-            result_zero_piece_count.expect_err("Expected PieceCountZero error for zero pieces coded together"),
-            RLNCError::PieceCountZero
-        );
-
-        // Test case 4: `full_coded_piece_byte_len` is not greater than `num_pieces_coded_together`
-        // Case 4.1: Equal
-        let result_equal_len = Recoder::new(
-            data_non_empty.clone(),
-            num_pieces_coded_together, // full_coded_piece_byte_len = num_pieces_coded_together
-            num_pieces_coded_together,
-        );
-        assert!(result_equal_len.is_err());
-        assert_eq!(
-            result_equal_len.expect_err("Expected PieceLengthTooShort error when full length equals piece count"),
-            RLNCError::PieceLengthTooShort
-        );
-
-        // Case 4.2: Less than
-        let result_less_len = Recoder::new(
-            data_non_empty.clone(),
-            num_pieces_coded_together - 1, // full_coded_piece_byte_len < num_pieces_coded_together
-            num_pieces_coded_together,
-        );
-        assert!(result_less_len.is_err());
-        assert_eq!(
-            result_less_len.expect_err("Expected PieceLengthTooShort error when full length is less than piece count"),
-            RLNCError::PieceLengthTooShort
-        );
-
-        // Test case 5: Valid input (using existing encoder setup to generate valid data)
+        // Test case 3: Valid input (using existing encoder setup to generate valid data)
         let num_pieces_to_recode_with = 5;
         let coded_pieces_for_recoder: Vec<u8> = (0..num_pieces_to_recode_with).flat_map(|_| encoder.code(&mut rng)).collect();
 
-        let result_valid = Recoder::new(coded_pieces_for_recoder, full_coded_piece_byte_len, num_pieces_coded_together);
+        let result_valid = Recoder::new(coded_pieces_for_recoder, encoder.piece_byte_len(), encoder.piece_count());
         assert!(result_valid.is_ok());
         let recoder = result_valid.expect("Expected Recoder to be created successfully with valid inputs");
-        assert_eq!(recoder.get_original_num_pieces_coded_together(), num_pieces_coded_together);
-        assert_eq!(recoder.get_num_pieces_recoded_together(), num_pieces_to_recode_with);
+        assert_eq!(recoder.piece_count(), encoder.piece_count());
+        assert_eq!(recoder.recoded_piece_count(), num_pieces_to_recode_with);
     }
 
     #[test]
@@ -262,11 +217,11 @@ mod tests {
         let encoder = Encoder::new(data, piece_count).expect("Failed to create Encoder for invalid inputs test");
 
         let coded_pieces_for_recoder: Vec<u8> = (0..num_pieces_to_recode_with).flat_map(|_| encoder.code(&mut rng)).collect();
-        let mut recoder = Recoder::new(coded_pieces_for_recoder, encoder.get_full_coded_piece_byte_len(), encoder.get_piece_count())
+        let mut recoder = Recoder::new(coded_pieces_for_recoder, encoder.piece_byte_len(), encoder.piece_count())
             .expect("Failed to create Recoder for invalid inputs test");
 
         // Test case 1: Recoded piece buffer is shorter than expected
-        let mut short_recoded_piece = vec![0u8; recoder.get_full_coded_piece_byte_len() - 1];
+        let mut short_recoded_piece = vec![0u8; recoder.full_coded_piece_byte_len() - 1];
         let result_short = recoder.recode_with_buf(&mut rng, &mut short_recoded_piece);
 
         assert!(result_short.is_err());
@@ -276,7 +231,7 @@ mod tests {
         );
 
         // Test case 2: Recoded piece buffer is longer than expected
-        let mut long_recoded_piece = vec![0u8; recoder.get_full_coded_piece_byte_len() + 1];
+        let mut long_recoded_piece = vec![0u8; recoder.full_coded_piece_byte_len() + 1];
         let result_long = recoder.recode_with_buf(&mut rng, &mut long_recoded_piece);
 
         assert!(result_long.is_err());
@@ -296,7 +251,7 @@ mod tests {
         );
 
         // Test case 4: Valid recoded piece buffer
-        let mut recoded_piece = vec![0u8; encoder.get_full_coded_piece_byte_len()];
+        let mut recoded_piece = vec![0u8; encoder.full_coded_piece_byte_len()];
         let result_valid = recoder.recode_with_buf(&mut rng, &mut recoded_piece);
 
         assert!(result_valid.is_ok());
@@ -312,21 +267,15 @@ mod tests {
         let encoder = Encoder::new(data, piece_count).expect("Failed to create Encoder for recoder getters test");
 
         let num_pieces_to_recode_with = 10; // Number of coded pieces given to recoder
-        let full_coded_piece_byte_len = encoder.get_full_coded_piece_byte_len();
-        let original_piece_byte_len = encoder.get_piece_byte_len();
 
         let coded_pieces_for_recoder: Vec<u8> = (0..num_pieces_to_recode_with).flat_map(|_| encoder.code(&mut rng)).collect();
 
-        let recoder = Recoder::new(
-            coded_pieces_for_recoder,
-            full_coded_piece_byte_len,
-            piece_count, // `num_pieces_coded_together` from original encoder
-        )
-        .expect("Recoder creation failed");
+        let recoder = Recoder::new(coded_pieces_for_recoder, encoder.piece_byte_len(), encoder.piece_count())
+            .expect("Recoder creation failed");
 
-        assert_eq!(recoder.get_original_num_pieces_coded_together(), piece_count);
-        assert_eq!(recoder.get_num_pieces_recoded_together(), num_pieces_to_recode_with);
-        assert_eq!(recoder.get_piece_byte_len(), original_piece_byte_len);
-        assert_eq!(recoder.get_full_coded_piece_byte_len(), full_coded_piece_byte_len);
+        assert_eq!(recoder.piece_count(), encoder.piece_count());
+        assert_eq!(recoder.recoded_piece_count(), num_pieces_to_recode_with);
+        assert_eq!(recoder.piece_byte_len(), encoder.piece_byte_len());
+        assert_eq!(recoder.full_coded_piece_byte_len(), encoder.full_coded_piece_byte_len());
     }
 }

--- a/src/full/tests.rs
+++ b/src/full/tests.rs
@@ -24,7 +24,7 @@ fn prop_test_rlnc_encoder_decoder() {
         let data_copy = data.clone();
 
         let encoder = Encoder::new(data, piece_count).expect("Failed to create Encoder");
-        let mut decoder = Decoder::new(encoder.get_piece_byte_len(), encoder.get_piece_count()).expect("Failed to create Decoder");
+        let mut decoder = Decoder::new(encoder.piece_byte_len(), encoder.piece_count());
 
         loop {
             let coded_piece = encoder.code(&mut rng);
@@ -40,7 +40,7 @@ fn prop_test_rlnc_encoder_decoder() {
         }
 
         assert!(decoder.is_already_decoded());
-        let decoded_data = decoder.get_decoded_data().expect("Extracting decoded data must not fail!");
+        let decoded_data = decoder.into_decoded_data().expect("Extracting decoded data must not fail!");
 
         assert_eq!(data_copy, decoded_data);
     });
@@ -72,14 +72,14 @@ fn prop_test_rlnc_encoder_recoder_decoder() {
         let data_copy = data.clone();
 
         let encoder = Encoder::new(data, piece_count).expect("Failed to create Encoder");
-        let mut decoder = Decoder::new(encoder.get_piece_byte_len(), encoder.get_piece_count()).expect("Failed to create Decoder");
+        let mut decoder = Decoder::new(encoder.piece_byte_len(), encoder.piece_count());
 
         'OUTER: loop {
             let num_pieces_to_recode = rng.random_range(MIN_NUM_PIECES_TO_RECODE..=MAX_NUM_PIECES_TO_RECODE);
 
             let coded_pieces = (0..num_pieces_to_recode).flat_map(|_| encoder.code(&mut rng)).collect::<Vec<u8>>();
 
-            let mut recoder = Recoder::new(coded_pieces, encoder.get_full_coded_piece_byte_len(), encoder.get_piece_count())
+            let mut recoder = Recoder::new(coded_pieces, encoder.piece_byte_len(), encoder.piece_count())
                 .expect("Construction of RLNC recoder must not fail!");
 
             let num_recoded_pieces_to_use = rng.random_range(MIN_NUM_RECODED_PIECES_TO_USE..=MAX_NUM_RECODED_PIECES_TO_USE);
@@ -112,7 +112,7 @@ fn prop_test_rlnc_encoder_recoder_decoder() {
         }
 
         assert!(decoder.is_already_decoded());
-        let decoded_data = decoder.get_decoded_data().expect("Extracting decoded data must not fail!");
+        let decoded_data = decoder.into_decoded_data().expect("Extracting decoded data must not fail!");
 
         assert_eq!(data_copy, decoded_data);
     });
@@ -140,11 +140,11 @@ fn prop_test_rlnc_decoding_with_useless_pieces() {
         // Create Full RLNC Encoder
         let encoder = Encoder::new(data, piece_count).expect("Failed to create Encoder");
         // Create Full RLNC Decoder
-        let mut decoder = Decoder::new(encoder.get_piece_byte_len(), encoder.get_piece_count()).expect("Failed to create Decoder");
+        let mut decoder = Decoder::new(encoder.piece_byte_len(), encoder.piece_count());
 
         // Reserve memory for holding coded pieces, which are to be used for recoding.
         let num_pieces_to_use_for_recoding = piece_count / 2;
-        let mut coded_pieces_for_recoding = Vec::with_capacity(encoder.get_full_coded_piece_byte_len() * num_pieces_to_use_for_recoding);
+        let mut coded_pieces_for_recoding = Vec::with_capacity(encoder.full_coded_piece_byte_len() * num_pieces_to_use_for_recoding);
 
         // Generate some coded pieces, push them into Decoder and keep their copy so that they can be used for recoding.
         (0..num_pieces_to_use_for_recoding).for_each(|_| {
@@ -165,7 +165,7 @@ fn prop_test_rlnc_decoding_with_useless_pieces() {
         // new pieces from previously consumed coded pieces. And those recoded pieces will all be useless, because the recoder will
         // just produce new linear combination of existing coded pieces, and they can't be linearly independent from all coded pieces
         // which were already seen by the Decoder.
-        let mut recoder = Recoder::new(coded_pieces_for_recoding, encoder.get_full_coded_piece_byte_len(), encoder.get_piece_count())
+        let mut recoder = Recoder::new(coded_pieces_for_recoding, encoder.piece_byte_len(), encoder.piece_count())
             .expect("Must be able to build a Recoder");
 
         // Hence in following loop, decoding process won't progress, because all the recoded pieces will be useless.
@@ -184,7 +184,7 @@ fn prop_test_rlnc_decoding_with_useless_pieces() {
         });
 
         // Finally, we can grab new coded pieces from directly the Encoder to finalize the decoding process.
-        while decoder.get_remaining_piece_count() > 0 {
+        while decoder.remaining_piece_count() > 0 {
             let coded_piece = encoder.code(&mut rng);
 
             match decoder.decode(&coded_piece) {
@@ -197,7 +197,7 @@ fn prop_test_rlnc_decoding_with_useless_pieces() {
         }
 
         assert!(decoder.is_already_decoded());
-        let decoded_data = decoder.get_decoded_data().expect("Extracting decoded data must not fail!");
+        let decoded_data = decoder.into_decoded_data().expect("Extracting decoded data must not fail!");
 
         assert_eq!(data_copy, decoded_data);
     });

--- a/src/full/types.rs
+++ b/src/full/types.rs
@@ -1,0 +1,74 @@
+/// Number of pieces data is split into for coding.
+///
+/// Guaranteed to be non-zero by construction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PieceCount(usize);
+
+impl PieceCount {
+    /// Creates a new `PieceCount` from the given value.
+    ///
+    /// Returns `None` if `value` is zero.
+    pub const fn new(value: usize) -> Option<Self> {
+        if value == 0 {
+            None
+        } else {
+            Some(Self(value))
+        }
+    }
+
+    /// Returns the underlying count as a `usize`.
+    pub const fn value(self) -> usize {
+        self.0
+    }
+}
+
+/// Byte length of each data piece after padding.
+///
+/// Guaranteed to be non-zero by construction.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct PieceByteLen(usize);
+
+impl PieceByteLen {
+    /// Creates a new `PieceByteLen` from the given value.
+    ///
+    /// Returns `None` if `value` is zero.
+    pub const fn new(value: usize) -> Option<Self> {
+        if value == 0 {
+            None
+        } else {
+            Some(Self(value))
+        }
+    }
+
+    /// Returns the underlying length as a `usize`.
+    pub const fn value(self) -> usize {
+        self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn piece_count_rejects_zero() {
+        assert_eq!(PieceCount::new(0), None);
+    }
+
+    #[test]
+    fn piece_count_accepts_non_zero() {
+        let pc = PieceCount::new(32).unwrap();
+        assert_eq!(pc.value(), 32);
+    }
+
+    #[test]
+    fn piece_byte_len_rejects_zero() {
+        assert_eq!(PieceByteLen::new(0), None);
+    }
+
+    #[test]
+    fn piece_byte_len_accepts_non_zero() {
+        let pbl = PieceByteLen::new(1024).unwrap();
+        assert_eq!(pbl.value(), 1024);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,8 @@
 //! -   **Flexible data handling**: Supports arbitrary byte lengths for input
 //!     data, with internal padding and boundary markers for robust decoding.
 //! -   **Error Handling**: Comprehensive `RLNCError` enum for various failure scenarios.
+//! -   **Type-safe API**: `PieceCount` and `PieceByteLen` newtypes prevent accidentally
+//!     swapping parameters of the same underlying type.
 //!
 //! ## Example Usage
 //!
@@ -78,10 +80,10 @@
 //! let coded_pieces_for_recoding: Vec<u8> = (0..num_pieces_for_recoding).flat_map(|_| encoder.code(&mut rng)).collect();
 //!
 //! // 4. Initialize the Recoder with 16 coded pieces
-//! let mut recoder = Recoder::new(coded_pieces_for_recoding, encoder.get_full_coded_piece_byte_len(), encoder.get_piece_count()).expect("Failed to create RLNC recoder");
+//! let mut recoder = Recoder::new(coded_pieces_for_recoding, encoder.piece_byte_len(), encoder.piece_count()).expect("Failed to create RLNC recoder");
 //!
 //! // 5. Initialize the Decoder
-//! let mut decoder = Decoder::new(encoder.get_piece_byte_len(), encoder.get_piece_count()).expect("Failed to create RLNC decoder");
+//! let mut decoder = Decoder::new(encoder.piece_byte_len(), encoder.piece_count());
 //!
 //! // 6. Generate a recoded piece, this is the piece to be sent to the decoder as first piece.
 //! let recoded_piece = recoder.recode(&mut rng);
@@ -101,10 +103,10 @@
 //!     }
 //! }
 //!
-//! // 5. Retrieve the decoded data
-//! let decoded_data = decoder.get_decoded_data().expect("Failed to retrieve decoded data even after all pieces are received");
+//! // 9. Retrieve the decoded data
+//! let decoded_data = decoder.into_decoded_data().expect("Failed to retrieve decoded data even after all pieces are received");
 //!
-//! // 6. Verify that the decoded data matches the original data
+//! // 10. Verify that the decoded data matches the original data
 //! assert_eq!(original_data_copy, decoded_data);
 //! println!("RLNC workflow completed successfully! Original data matches decoded data.");
 //! ```
@@ -115,11 +117,11 @@
 //!
 //! ```toml
 //! [dependencies]
-//! rlnc = "=0.8.7"                                      # On x86_64 and aarch64 targets, it offers fast encoding, recoding and decoding, using SIMD intrinsics.
+//! rlnc = "=0.9.0"                                      # On x86_64 and aarch64 targets, it offers fast encoding, recoding and decoding, using SIMD intrinsics.
 //! # or
-//! rlnc = { version = "=0.8.7", features = "parallel" } # Uses `rayon`-based data-parallelism for fast encoding/ recoding. Decoding is not yet parallelized.
+//! rlnc = { version = "=0.9.0", features = "parallel" } # Uses `rayon`-based data-parallelism for fast encoding/ recoding. Decoding is not yet parallelized.
 //!
-//! rand = { version = "=0.9.1" } # Required for random number generation
+//! rand = { version = "=0.9.2" } # Required for random number generation
 //! ```
 //!
 //! For more see README in `rlnc` repository @ <https://github.com/itzmeanjan/rlnc>.


### PR DESCRIPTION
Introduce PieceCount and PieceByteLen newtypes to prevent parameter swapping at call sites. Drop get_ prefixes on all getters per Rust API guidelines. Rename get_decoded_data to into_decoded_data to follow the consuming-method convention. Remove error variants made impossible by the new types (PieceLengthZero, PieceLengthTooShort). Decoder::new is now infallible since the newtypes guarantee non-zero inputs.